### PR TITLE
Replace flickering filename with animated progress indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog - syncnorris
 
+## [0.7.2] - 2026-03-14
+
+### Improvements
+- **GUI**: Replace flickering filename under progress bar with a smooth animated "Processing..." indicator that cycles every 500ms, shows "Done" on completion (#3)
+
 ## [0.7.1] - 2026-03-14
 
 ### Bug Fixes
-- **GUI**: Fix progress bar flickering — fraction now based on completed file count (monotonic) instead of per-worker file index which arrived out of order from concurrent workers (fixes #2)
+- **GUI**: Fix progress bar flickering — fraction now based on completed file count (monotonic) instead of per-worker file index which arrived out of order from concurrent workers (#2)
 
 ## [0.7.0] - 2026-03-14
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # syncnorris
 
-**Version**: v0.7.1
+**Version**: v0.7.2
 **Status**: Production-ready for one-way sync | **Experimental** for bidirectional sync
 **License**: MIT
 

--- a/internal/gui/layout.go
+++ b/internal/gui/layout.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"time"
 
 	"gioui.org/font"
 	"gioui.org/layout"
+	"gioui.org/op"
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
 	"gioui.org/unit"
@@ -485,12 +487,13 @@ func (a *appState) layoutProgress(gtx C) D {
 			if a.progress.TotalFiles > 0 {
 				info += fmt.Sprintf("  |  %d / %d files", a.progress.CurrentFile, a.progress.TotalFiles)
 			}
-			if a.progress.CurrentPath != "" {
-				path := a.progress.CurrentPath
-				if len(path) > 45 {
-					path = "..." + path[len(path)-42:]
-				}
-				info += fmt.Sprintf("  |  %s", path)
+			if a.isRunning {
+				dots := int(gtx.Now.UnixMilli()/500) % 4 // cycle 0..3 every 500ms
+				info += fmt.Sprintf("  |  Processing%s", "...."[:dots+1])
+				// Request continuous redraw for animation
+				gtx.Execute(op.InvalidateCmd{At: gtx.Now.Add(500 * time.Millisecond)})
+			} else if a.progress.Fraction >= 1 {
+				info += "  |  Done"
 			}
 			lbl := material.Caption(a.theme, info)
 			lbl.Color = colorTextMuted


### PR DESCRIPTION
## Summary
- Replace the rapidly changing filename under the progress bar with a smooth `Processing....` animation (dots cycle every 500ms)
- Shows `Done` when the operation completes
- Uses `gtx.Now` for timing and `op.InvalidateCmd` for scheduled redraws — no goroutine or timer needed

Ref #3

## Test plan
- [ ] Launch `syncnorris gui`, run a sync operation
- [ ] Verify the text under the progress bar shows "Processing." → "Processing.." → "Processing..." → "Processing...." smoothly
- [ ] Verify it shows "Done" after completion
- [ ] Verify no flickering filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)