### PR TITLE
Add real-time bandwidth graph in GUI progress section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - syncnorris
 
+## [0.7.3] - 2026-03-14
+
+### Features
+- **GUI**: Add real-time bandwidth graph in progress section — shows current and average transfer speed as text, with a filled area chart over a 60-second sliding window. Y-axis auto-scales to peak bandwidth. Graph height is compact (50dp) to fit the existing layout (#5)
+
 ## [0.7.2] - 2026-03-14
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # syncnorris
 
-**Version**: v0.7.2
+**Version**: v0.7.3
 **Status**: Production-ready for one-way sync | **Experimental** for bidirectional sync
 **License**: MIT
 

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -78,7 +78,8 @@ type appState struct {
 	logEntries []LogEntry
 
 	// Progress
-	progress ProgressState
+	progress  ProgressState
+	bandwidth *BandwidthTracker
 
 	// Running state
 	isRunning bool
@@ -158,6 +159,8 @@ func (a *appState) init() {
 	a.deleteCheck.Value = s.Delete
 	a.createDestCheck.Value = s.CreateDest
 
+	a.bandwidth = NewBandwidthTracker()
+
 	a.logList.List.Axis = layout.Vertical
 	a.logList.List.ScrollToEnd = true
 
@@ -205,6 +208,7 @@ func (a *appState) consumeEvents() {
 		case eventProgress:
 			if ev.Progress != nil {
 				a.progress = *ev.Progress
+				a.bandwidth.Update(ev.Progress.BytesTransferred)
 			}
 		case eventComplete:
 			a.isRunning = false
@@ -389,6 +393,7 @@ func (a *appState) startOperation(dryRun bool) {
 	a.logEntries = nil
 	a.progress = ProgressState{}
 	a.report = nil
+	a.bandwidth.Reset()
 	a.isRunning = true
 	a.statusLevel = "info"
 	if dryRun {

--- a/internal/gui/bandwidth.go
+++ b/internal/gui/bandwidth.go
@@ -1,0 +1,124 @@
+//go:build !nogui
+
+package gui
+
+import (
+	"sync"
+	"time"
+)
+
+const bwWindowSize = 60 // 60 samples = 1 minute of history at 1 sample/sec
+
+// BandwidthSample holds one second of bandwidth data.
+type BandwidthSample struct {
+	BytesPerSec float64
+	Time        time.Time
+}
+
+// BandwidthTracker collects bandwidth samples over a sliding window.
+type BandwidthTracker struct {
+	mu             sync.Mutex
+	samples        [bwWindowSize]BandwidthSample
+	head           int // next write position (ring buffer)
+	count          int // number of valid samples
+	lastBytes      int64
+	lastSampleTime time.Time
+	totalBytes     int64
+	startTime      time.Time
+}
+
+// NewBandwidthTracker creates a new tracker.
+func NewBandwidthTracker() *BandwidthTracker {
+	now := time.Now()
+	return &BandwidthTracker{
+		lastSampleTime: now,
+		startTime:      now,
+	}
+}
+
+// Update records the current cumulative bytes transferred.
+// Call this frequently; it auto-samples once per second.
+func (bt *BandwidthTracker) Update(totalBytes int64) {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	bt.totalBytes = totalBytes
+	now := time.Now()
+	elapsed := now.Sub(bt.lastSampleTime)
+
+	if elapsed < time.Second {
+		return
+	}
+
+	// Compute bytes/sec since last sample
+	delta := totalBytes - bt.lastBytes
+	secs := elapsed.Seconds()
+	bps := float64(delta) / secs
+
+	bt.samples[bt.head] = BandwidthSample{
+		BytesPerSec: bps,
+		Time:        now,
+	}
+	bt.head = (bt.head + 1) % bwWindowSize
+	if bt.count < bwWindowSize {
+		bt.count++
+	}
+
+	bt.lastBytes = totalBytes
+	bt.lastSampleTime = now
+}
+
+// Current returns the most recent bandwidth sample (bytes/sec).
+func (bt *BandwidthTracker) Current() float64 {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	if bt.count == 0 {
+		return 0
+	}
+	idx := (bt.head - 1 + bwWindowSize) % bwWindowSize
+	return bt.samples[idx].BytesPerSec
+}
+
+// Average returns the average bandwidth since the start (bytes/sec).
+func (bt *BandwidthTracker) Average() float64 {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	elapsed := time.Since(bt.startTime).Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+	return float64(bt.totalBytes) / elapsed
+}
+
+// Samples returns up to the last bwWindowSize samples (oldest first).
+func (bt *BandwidthTracker) Samples() []BandwidthSample {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	if bt.count == 0 {
+		return nil
+	}
+
+	result := make([]BandwidthSample, bt.count)
+	start := (bt.head - bt.count + bwWindowSize) % bwWindowSize
+	for i := 0; i < bt.count; i++ {
+		result[i] = bt.samples[(start+i)%bwWindowSize]
+	}
+	return result
+}
+
+// Reset clears all samples and counters.
+func (bt *BandwidthTracker) Reset() {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	now := time.Now()
+	bt.count = 0
+	bt.head = 0
+	bt.lastBytes = 0
+	bt.totalBytes = 0
+	bt.lastSampleTime = now
+	bt.startTime = now
+}

--- a/internal/gui/formatter.go
+++ b/internal/gui/formatter.go
@@ -44,11 +44,12 @@ func (s RunningStats) Total() int {
 
 // ProgressState holds current progress for the UI
 type ProgressState struct {
-	Fraction    float32
-	CurrentFile int
-	TotalFiles  int
-	CurrentPath string
-	Stats       RunningStats
+	Fraction         float32
+	CurrentFile      int
+	TotalFiles       int
+	CurrentPath      string
+	Stats            RunningStats
+	BytesTransferred int64
 }
 
 // UIEvent carries updates from the formatter to the GUI event loop
@@ -74,9 +75,10 @@ type GUIFormatter struct {
 	totalFiles int
 	startTime  time.Time
 
-	mu    sync.Mutex
-	files map[string]*fileState
-	stats RunningStats
+	mu               sync.Mutex
+	files            map[string]*fileState
+	stats            RunningStats
+	bytesTransferred int64
 }
 
 var _ output.Formatter = (*GUIFormatter)(nil)
@@ -132,16 +134,19 @@ func (f *GUIFormatter) Progress(update output.ProgressUpdate) error {
 		switch action {
 		case "COPY":
 			f.stats.Copied++
+			f.bytesTransferred += update.TotalBytes
 		case "UPDATE":
 			f.stats.Updated++
+			f.bytesTransferred += update.TotalBytes
 		case "SKIP":
 			f.stats.Skipped++
 		}
 		stats := f.stats
+		bytes := f.bytesTransferred
 		f.mu.Unlock()
 
 		f.sendLog(action, fmt.Sprintf("%s (%s)", update.FilePath, formatSize(update.TotalBytes)))
-		f.sendProgressWithStats(stats, update.FilePath)
+		f.sendProgressWithStatsAndBytes(stats, bytes, update.FilePath)
 
 	case "file_error":
 		f.mu.Lock()
@@ -237,15 +242,17 @@ func (f *GUIFormatter) sendProgress(completed, total int, path string) {
 	}
 	f.mu.Lock()
 	stats := f.stats
+	bytes := f.bytesTransferred
 	f.mu.Unlock()
 	f.send(UIEvent{
 		Type: eventProgress,
 		Progress: &ProgressState{
-			Fraction:    frac,
-			CurrentFile: completed,
-			TotalFiles:  total,
-			CurrentPath: path,
-			Stats:       stats,
+			Fraction:         frac,
+			CurrentFile:      completed,
+			TotalFiles:       total,
+			CurrentPath:      path,
+			Stats:            stats,
+			BytesTransferred: bytes,
 		},
 	})
 }
@@ -259,8 +266,15 @@ func (f *GUIFormatter) sendCurrentProgress(path string) {
 }
 
 // sendProgressWithStats computes fraction from stats.Total() (completed files).
-// This ensures the progress bar never regresses.
 func (f *GUIFormatter) sendProgressWithStats(stats RunningStats, path string) {
+	f.mu.Lock()
+	bytes := f.bytesTransferred
+	f.mu.Unlock()
+	f.sendProgressWithStatsAndBytes(stats, bytes, path)
+}
+
+// sendProgressWithStatsAndBytes sends a progress event with all data.
+func (f *GUIFormatter) sendProgressWithStatsAndBytes(stats RunningStats, bytes int64, path string) {
 	completed := stats.Total()
 	total := f.totalFiles
 	frac := float32(0)
@@ -273,11 +287,12 @@ func (f *GUIFormatter) sendProgressWithStats(stats RunningStats, path string) {
 	f.send(UIEvent{
 		Type: eventProgress,
 		Progress: &ProgressState{
-			Fraction:    frac,
-			CurrentFile: completed,
-			TotalFiles:  total,
-			CurrentPath: path,
-			Stats:       stats,
+			Fraction:         frac,
+			CurrentFile:      completed,
+			TotalFiles:       total,
+			CurrentPath:      path,
+			Stats:            stats,
+			BytesTransferred: bytes,
 		},
 	})
 }

--- a/internal/gui/layout.go
+++ b/internal/gui/layout.go
@@ -8,6 +8,7 @@ import (
 	"image/color"
 	"time"
 
+	"gioui.org/f32"
 	"gioui.org/font"
 	"gioui.org/layout"
 	"gioui.org/op"
@@ -523,6 +524,108 @@ func (a *appState) layoutProgress(gtx C) D {
 				}),
 			)
 		}),
+		// Bandwidth graph
+		layout.Rigid(spacer(4)),
+		layout.Rigid(a.layoutBandwidth),
+	)
+}
+
+const graphHeight = unit.Dp(50)
+
+func (a *appState) layoutBandwidth(gtx C) D {
+	current := a.bandwidth.Current()
+	avg := a.bandwidth.Average()
+	samples := a.bandwidth.Samples()
+
+	// Text labels
+	bwText := fmt.Sprintf("Current: %s/s  |  Average: %s/s", formatSize(int64(current)), formatSize(int64(avg)))
+
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+		layout.Rigid(func(gtx C) D {
+			lbl := material.Caption(a.theme, bwText)
+			lbl.Color = colorTextMuted
+			return lbl.Layout(gtx)
+		}),
+		layout.Rigid(spacer(2)),
+		layout.Rigid(func(gtx C) D {
+			// Graph area
+			h := gtx.Dp(graphHeight)
+			w := gtx.Constraints.Max.X
+			size := image.Point{X: w, Y: h}
+			gtx.Constraints = layout.Exact(size)
+
+			// Background
+			paint.FillShape(gtx.Ops, colorLogBg, clip.Rect{Max: size}.Op())
+
+			if len(samples) < 2 {
+				// Not enough data — draw empty box
+				return bordered(gtx, func(gtx C) D {
+					paint.FillShape(gtx.Ops, colorLogBg, clip.Rect{Max: size}.Op())
+					return D{Size: size}
+				})
+			}
+
+			// Find max value for Y scale
+			maxVal := float64(0)
+			for _, s := range samples {
+				if s.BytesPerSec > maxVal {
+					maxVal = s.BytesPerSec
+				}
+			}
+			if maxVal == 0 {
+				maxVal = 1 // avoid division by zero
+			}
+
+			// Draw filled area chart
+			n := len(samples)
+			stepX := float32(w) / float32(n-1)
+
+			var path clip.Path
+			path.Begin(gtx.Ops)
+			// Start at bottom-left
+			path.MoveTo(f32Point(0, float32(h)))
+			// Line to first data point
+			y0 := float32(h) - float32(h)*float32(samples[0].BytesPerSec/maxVal)
+			path.LineTo(f32Point(0, y0))
+			// Data points
+			for i := 1; i < n; i++ {
+				x := stepX * float32(i)
+				y := float32(h) - float32(h)*float32(samples[i].BytesPerSec/maxVal)
+				path.LineTo(f32Point(x, y))
+			}
+			// Close to bottom-right then bottom-left
+			path.LineTo(f32Point(float32(w), float32(h)))
+			path.Close()
+
+			// Fill with semi-transparent primary color
+			fillColor := colorPrimary
+			fillColor.A = 0x40
+			paint.FillShape(gtx.Ops, fillColor, clip.Outline{Path: path.End()}.Op())
+
+			// Draw the line on top
+			var linePath clip.Path
+			linePath.Begin(gtx.Ops)
+			ly0 := float32(h) - float32(h)*float32(samples[0].BytesPerSec/maxVal)
+			linePath.MoveTo(f32Point(0, ly0))
+			for i := 1; i < n; i++ {
+				x := stepX * float32(i)
+				y := float32(h) - float32(h)*float32(samples[i].BytesPerSec/maxVal)
+				linePath.LineTo(f32Point(x, y))
+			}
+			lineColor := colorPrimary
+			lineColor.A = 0xa0
+			paint.FillShape(gtx.Ops, lineColor,
+				clip.Stroke{Path: linePath.End(), Width: float32(gtx.Dp(unit.Dp(1.5)))}.Op())
+
+			// Border around the graph
+			paint.FillShape(gtx.Ops, colorBorder,
+				clip.Stroke{
+					Path:  clip.Rect{Max: size}.Path(),
+					Width: float32(gtx.Dp(unit.Dp(1))),
+				}.Op())
+
+			return D{Size: size}
+		}),
 	)
 }
 
@@ -603,4 +706,8 @@ func levelColor(level string) color.NRGBA {
 	default:
 		return colorText
 	}
+}
+
+func f32Point(x, y float32) f32.Point {
+	return f32.Point{X: x, Y: y}
 }


### PR DESCRIPTION
## Summary
- Add a real-time bandwidth graph below the progress stats
- Shows current speed and average speed as text labels
- Filled area chart (60-second sliding window, 1 sample/sec)
- Auto-scaling Y axis, compact height (50dp)
- New `BandwidthTracker` (ring buffer) collects samples from cumulative bytes transferred

Ref #5

## Test plan
- [ ] Launch `syncnorris gui`, sync a directory with some files
- [ ] Verify bandwidth text shows current and average speed
- [ ] Verify the graph draws a filled area chart that updates during sync
- [ ] Verify the graph auto-scales when speed changes
- [ ] Verify graph resets when starting a new operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)