### PR TITLE
Fix bandwidth graph empty data and always show progress section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - syncnorris
 
+## [0.7.4] - 2026-03-14
+
+### Bug Fixes
+- **GUI**: Bandwidth graph now tracks all processed bytes (including identical/skipped files), not just transferred bytes from copy/update operations — graph is no longer empty when all files are identical (#7)
+- **GUI**: Progress section (bar, stats, bandwidth graph) is always visible to avoid layout shifts when starting a job (#7)
+
 ## [0.7.3] - 2026-03-14
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # syncnorris
 
-**Version**: v0.7.3
+**Version**: v0.7.4
 **Status**: Production-ready for one-way sync | **Experimental** for bidirectional sync
 **License**: MIT
 

--- a/internal/gui/formatter.go
+++ b/internal/gui/formatter.go
@@ -134,13 +134,12 @@ func (f *GUIFormatter) Progress(update output.ProgressUpdate) error {
 		switch action {
 		case "COPY":
 			f.stats.Copied++
-			f.bytesTransferred += update.TotalBytes
 		case "UPDATE":
 			f.stats.Updated++
-			f.bytesTransferred += update.TotalBytes
 		case "SKIP":
 			f.stats.Skipped++
 		}
+		f.bytesTransferred += update.TotalBytes
 		stats := f.stats
 		bytes := f.bytesTransferred
 		f.mu.Unlock()

--- a/internal/gui/layout.go
+++ b/internal/gui/layout.go
@@ -472,9 +472,6 @@ func (a *appState) layoutActions(gtx C) D {
 // --- Progress ---
 
 func (a *appState) layoutProgress(gtx C) D {
-	if !a.isRunning && a.progress.Fraction == 0 {
-		return D{}
-	}
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 		layout.Rigid(func(gtx C) D {
 			bar := material.ProgressBar(a.theme, a.progress.Fraction)


### PR DESCRIPTION
## Summary
- Track all processed bytes (COPY + UPDATE + SKIP) in bandwidth tracker, not just transferred bytes — graph no longer empty when all files are identical
- Progress section (bar, stats, bandwidth graph) always visible to avoid layout shifts

Ref #7

## Test plan
- [ ] Sync two identical directories → bandwidth graph should show read/compare throughput
- [ ] Sync with actual file changes → bandwidth graph shows transfer speed
- [ ] Progress section visible before any operation is started (empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)