### PR TITLE
Fix bandwidth graph real-time tracking and add average line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - syncnorris
 
+## [0.7.5] - 2026-03-14
+
+### Bug Fixes
+- **GUI**: Bandwidth graph now shows real-time data by tracking in-flight bytes from `file_progress` events, not just completed file totals — eliminates the spiky pattern (#10)
+- **GUI**: Added dashed red average line on the bandwidth graph for visual reference (#10)
+
 ## [0.7.4] - 2026-03-14
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # syncnorris
 
-**Version**: v0.7.4
+**Version**: v0.7.5
 **Status**: Production-ready for one-way sync | **Experimental** for bidirectional sync
 **License**: MIT
 

--- a/internal/gui/formatter.go
+++ b/internal/gui/formatter.go
@@ -61,10 +61,11 @@ type UIEvent struct {
 	Error    error
 }
 
-// fileState tracks the event sequence for a single file.
+// fileState tracks the event sequence and in-flight bytes for a single file.
 type fileState struct {
-	hadCompare bool
-	hadCopy    bool
+	hadCompare   bool
+	hadCopy      bool
+	bytesWritten int64 // latest BytesWritten from file_progress
 }
 
 // GUIFormatter implements output.Formatter for the GUI.
@@ -122,7 +123,11 @@ func (f *GUIFormatter) Progress(update output.ProgressUpdate) error {
 		f.sendCurrentProgress(update.FilePath)
 
 	case "file_progress":
-		// No fraction change for in-progress files, just update the path
+		f.mu.Lock()
+		if s := f.files[update.FilePath]; s != nil {
+			s.bytesWritten = update.BytesWritten
+		}
+		f.mu.Unlock()
 		f.sendCurrentProgress(update.FilePath)
 
 	case "file_complete":
@@ -141,11 +146,10 @@ func (f *GUIFormatter) Progress(update output.ProgressUpdate) error {
 		}
 		f.bytesTransferred += update.TotalBytes
 		stats := f.stats
-		bytes := f.bytesTransferred
 		f.mu.Unlock()
 
 		f.sendLog(action, fmt.Sprintf("%s (%s)", update.FilePath, formatSize(update.TotalBytes)))
-		f.sendProgressWithStatsAndBytes(stats, bytes, update.FilePath)
+		f.sendProgressWithStats(stats, update.FilePath)
 
 	case "file_error":
 		f.mu.Lock()
@@ -214,6 +218,16 @@ func (f *GUIFormatter) Error(err error) error {
 	return nil
 }
 
+// totalBytesProcessed returns bytesTransferred (completed) + sum of in-flight bytes.
+// Caller must hold f.mu.
+func (f *GUIFormatter) totalBytesProcessed() int64 {
+	total := f.bytesTransferred
+	for _, s := range f.files {
+		total += s.bytesWritten
+	}
+	return total
+}
+
 func (f *GUIFormatter) getOrCreateFile(path string) *fileState {
 	s := f.files[path]
 	if s == nil {
@@ -241,7 +255,7 @@ func (f *GUIFormatter) sendProgress(completed, total int, path string) {
 	}
 	f.mu.Lock()
 	stats := f.stats
-	bytes := f.bytesTransferred
+	bytes := f.totalBytesProcessed()
 	f.mu.Unlock()
 	f.send(UIEvent{
 		Type: eventProgress,
@@ -256,24 +270,41 @@ func (f *GUIFormatter) sendProgress(completed, total int, path string) {
 	})
 }
 
-// sendCurrentProgress sends progress based on the current completed file count from stats.
+// sendCurrentProgress sends progress based on current completed files and in-flight bytes.
 func (f *GUIFormatter) sendCurrentProgress(path string) {
 	f.mu.Lock()
 	stats := f.stats
+	bytes := f.totalBytesProcessed()
+	completed := stats.Total()
 	f.mu.Unlock()
-	f.sendProgressWithStats(stats, path)
+
+	total := f.totalFiles
+	frac := float32(0)
+	if total > 0 {
+		frac = float32(completed) / float32(total)
+		if frac > 1 {
+			frac = 1
+		}
+	}
+	f.send(UIEvent{
+		Type: eventProgress,
+		Progress: &ProgressState{
+			Fraction:         frac,
+			CurrentFile:      completed,
+			TotalFiles:       total,
+			CurrentPath:      path,
+			Stats:            stats,
+			BytesTransferred: bytes,
+		},
+	})
 }
 
-// sendProgressWithStats computes fraction from stats.Total() (completed files).
+// sendProgressWithStats sends progress with pre-computed stats.
 func (f *GUIFormatter) sendProgressWithStats(stats RunningStats, path string) {
 	f.mu.Lock()
-	bytes := f.bytesTransferred
+	bytes := f.totalBytesProcessed()
 	f.mu.Unlock()
-	f.sendProgressWithStatsAndBytes(stats, bytes, path)
-}
 
-// sendProgressWithStatsAndBytes sends a progress event with all data.
-func (f *GUIFormatter) sendProgressWithStatsAndBytes(stats RunningStats, bytes int64, path string) {
 	completed := stats.Total()
 	total := f.totalFiles
 	frac := float32(0)

--- a/internal/gui/layout.go
+++ b/internal/gui/layout.go
@@ -562,8 +562,8 @@ func (a *appState) layoutBandwidth(gtx C) D {
 				})
 			}
 
-			// Find max value for Y scale
-			maxVal := float64(0)
+			// Find max value for Y scale (include average so line is always visible)
+			maxVal := avg
 			for _, s := range samples {
 				if s.BytesPerSec > maxVal {
 					maxVal = s.BytesPerSec
@@ -613,6 +613,27 @@ func (a *appState) layoutBandwidth(gtx C) D {
 			lineColor.A = 0xa0
 			paint.FillShape(gtx.Ops, lineColor,
 				clip.Stroke{Path: linePath.End(), Width: float32(gtx.Dp(unit.Dp(1.5)))}.Op())
+
+			// Average line (dashed red) — simulated with short segments
+			if avg > 0 {
+				avgY := float32(h) - float32(h)*float32(avg/maxVal)
+				dashLen := float32(gtx.Dp(unit.Dp(6)))
+				gapLen := float32(gtx.Dp(unit.Dp(4)))
+				x := float32(0)
+				for x < float32(w) {
+					endX := x + dashLen
+					if endX > float32(w) {
+						endX = float32(w)
+					}
+					var dash clip.Path
+					dash.Begin(gtx.Ops)
+					dash.MoveTo(f32Point(x, avgY))
+					dash.LineTo(f32Point(endX, avgY))
+					paint.FillShape(gtx.Ops, colorError,
+						clip.Stroke{Path: dash.End(), Width: float32(gtx.Dp(unit.Dp(1)))}.Op())
+					x = endX + gapLen
+				}
+			}
 
 			// Border around the graph
 			paint.FillShape(gtx.Ops, colorBorder,


### PR DESCRIPTION
## Summary
- Track in-flight bytes from `file_progress` events (not just completed files) for smooth real-time bandwidth data
- `totalBytesProcessed()` = completed bytes + sum of per-file in-flight bytes
- Add dashed red average line on the bandwidth graph
- Y-axis scale includes average so the line is always visible

Ref #10

## Test plan
- [x] Sync a directory with large files → bandwidth graph should show smooth curve, not spikes
- [x] Verify dashed red average line appears and updates
- [x] Sync identical files → graph shows read/compare throughput smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)