### PR TITLE
Launch GUI by default, hide Windows console, add .desktop file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
             archive: zip
             cgo: '0'
             ext: .exe
+            ldextra: -H windowsgui
 
     runs-on: ${{ matrix.os }}
 
@@ -104,7 +105,7 @@ jobs:
         run: |
           BINARY="syncnorris${{ matrix.ext }}"
           go build \
-            -ldflags="-s -w -X main.version=${{ steps.version.outputs.version }} -X main.commit=${{ steps.version.outputs.commit }} -X main.date=${{ steps.version.outputs.date }}" \
+            -ldflags="-s -w ${{ matrix.ldextra }} -X main.version=${{ steps.version.outputs.version }} -X main.commit=${{ steps.version.outputs.commit }} -X main.date=${{ steps.version.outputs.date }}" \
             -o "$BINARY" \
             cmd/syncnorris/main.go
 
@@ -114,7 +115,11 @@ jobs:
         shell: bash
         run: |
           ARCHIVE="syncnorris_${{ steps.version.outputs.version }}_${{ matrix.suffix }}.tar.gz"
-          tar czf "$ARCHIVE" syncnorris LICENSE README.md THIRD_PARTY_LICENSES.md
+          FILES="syncnorris LICENSE README.md THIRD_PARTY_LICENSES.md"
+          if [ "${{ matrix.goos }}" = "linux" ]; then
+            FILES="$FILES syncnorris.desktop"
+          fi
+          tar czf "$ARCHIVE" $FILES
           echo "archive=$ARCHIVE" >> "$GITHUB_ENV"
 
       - name: Package (zip)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - syncnorris
 
+## [0.7.6] - 2026-03-14
+
+### Improvements
+- **GUI**: Running `syncnorris` without arguments now launches the GUI directly (no need for `syncnorris gui`)
+- **Windows**: Console window hidden on launch (`-H windowsgui` ldflags) — app behaves as a native desktop application
+- **Linux**: Added `syncnorris.desktop` file for desktop environment integration (launch from app menu, no terminal)
+- CLI-only builds (`-tags nogui`) fall back to showing help when no subcommand is given
+
 ## [0.7.5] - 2026-03-14
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # syncnorris
 
-**Version**: v0.7.5
+**Version**: v0.7.6
 **Status**: Production-ready for one-way sync | **Experimental** for bidirectional sync
 **License**: MIT
 

--- a/cmd/syncnorris/main.go
+++ b/cmd/syncnorris/main.go
@@ -32,10 +32,13 @@ func run() error {
 		Short: "Cross-platform file synchronization utility",
 		Long: `syncnorris is a cross-platform file synchronization utility built in Go.
 It supports one-way and bidirectional synchronization between local folders,
-network shares, and remote storage with multiple comparison methods.`,
+network shares, and remote storage with multiple comparison methods.
+
+Running without a subcommand launches the graphical user interface.`,
 		Version:       version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		RunE:          cli.DefaultRunE,
 	}
 
 	// Add global flags

--- a/internal/cli/gui.go
+++ b/internal/cli/gui.go
@@ -18,3 +18,8 @@ func NewGUICommand() *cobra.Command {
 		},
 	}
 }
+
+// DefaultRunE launches the GUI when no subcommand is given.
+func DefaultRunE(cmd *cobra.Command, args []string) error {
+	return gui.Run()
+}

--- a/internal/cli/gui_stub.go
+++ b/internal/cli/gui_stub.go
@@ -18,3 +18,8 @@ func NewGUICommand() *cobra.Command {
 		},
 	}
 }
+
+// DefaultRunE shows help when no subcommand is given (GUI not available).
+func DefaultRunE(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
+}

--- a/syncnorris.desktop
+++ b/syncnorris.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=SyncNorris
+Comment=Cross-platform file synchronization utility
+Exec=syncnorris
+Terminal=false
+Type=Application
+Categories=Utility;FileTools;
+Keywords=sync;backup;files;copy;


### PR DESCRIPTION
## Summary
- `syncnorris` (no args) now launches the GUI directly
- Windows: `-H windowsgui` hides the console window (native desktop app feel)
- Linux: `syncnorris.desktop` included in release archives for desktop integration
- CLI-only builds (`nogui`) fall back to showing help

Ref #9

## Test plan
- [ ] Run `./syncnorris` without arguments → GUI opens
- [ ] Run `./syncnorris sync -s ... -d ...` → CLI works as before
- [ ] Run `./syncnorris gui` → GUI opens (still works)
- [ ] Verify `.desktop` file is in Linux tar.gz archive
- [ ] Build with `-tags nogui`: `./syncnorris` shows help

🤖 Generated with [Claude Code](https://claude.com/claude-code)