### PR TITLE
Fix CLI broken by v0.7.6 default GUI launch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,6 @@ jobs:
             archive: zip
             cgo: '0'
             ext: .exe
-            ldextra: -H windowsgui
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - syncnorris
 
+## [0.7.7] - 2026-03-14
+
+### Bug Fixes
+- **CLI**: Fix CLI broken by v0.7.6 — `--help`, `--version`, `sync`, `compare` now work correctly again. GUI only launches when invoked with zero arguments (#13)
+- **Windows**: Remove `-H windowsgui` that hid the console and broke all CLI output on Windows (#13)
+
 ## [0.7.6] - 2026-03-14
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # syncnorris
 
-**Version**: v0.7.6
+**Version**: v0.7.7
 **Status**: Production-ready for one-way sync | **Experimental** for bidirectional sync
 **License**: MIT
 

--- a/cmd/syncnorris/main.go
+++ b/cmd/syncnorris/main.go
@@ -38,7 +38,14 @@ Running without a subcommand launches the graphical user interface.`,
 		Version:       version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE:          cli.DefaultRunE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Launch GUI only when invoked with no arguments at all.
+			// Any flag (--help, --version, --verbose, etc.) falls through to help.
+			if len(os.Args) == 1 {
+				return cli.DefaultRunE(cmd, args)
+			}
+			return cmd.Help()
+		},
 	}
 
 	// Add global flags


### PR DESCRIPTION
## Summary
- GUI only launches when `syncnorris` is invoked with zero arguments (`len(os.Args) == 1`)
- `--help`, `--version`, `sync`, `compare` and all other subcommands/flags work correctly again
- Removed `-H windowsgui` from Windows build that hid the console and broke all CLI output

Ref #13

## Test plan
- [ ] `syncnorris` (no args) → GUI opens
- [ ] `syncnorris --help` → shows help text
- [ ] `syncnorris --version` → shows version
- [ ] `syncnorris sync -s /src -d /dst` → CLI sync works
- [ ] `syncnorris compare -s /src -d /dst` → CLI compare works
- [ ] `syncnorris gui` → GUI opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)